### PR TITLE
Have `make install` create the bin dir within prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ clean-lib:
 prefix?=/usr/local
 
 install: $(CLI_TGT)
+	install -d $(prefix)/bin
 	install -m 0755 $(CLI_TGT) $(prefix)/bin
 
 uninstall:


### PR DESCRIPTION
If the prefix location did not have a `bin` directory the executable would be copied over to the filename `$(prefix)/bin` directly, not `$(prefix)/bin/serhex`.
